### PR TITLE
Add load path to bin/framework-generate

### DIFF
--- a/bin/framework-generate
+++ b/bin/framework-generate
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.push File.expand_path("../../lib", __FILE__)
+
 require 'framework-generate'
 
 FrameworkGenerate::Runner.generate


### PR DESCRIPTION
Wanted to contribute to this tool, but I encountered a first issue: no way to execute the script. In the end, I don't really know why I wasn't able to execute it (was getting `cannot load file` from require...), so I went looking at other ruby library to finally see they had this line in their bin.

I'm not sure why or if it is really necessary, but that allowed me to launch locally the executable.

Merged or closed this PR is up to you, I don't have enough knowledge in ruby to arguments if it's a wether a good idea to add this or no.